### PR TITLE
Improve text caching

### DIFF
--- a/src/__tests__/characters/basic.ts
+++ b/src/__tests__/characters/basic.ts
@@ -1,13 +1,26 @@
 import BasicCharacterStrategy from "../../characters/basic";
 
 describe('BasicCharacterStrategy', () => {
-    describe('buildChar', () => {
-        test('turns a string into a two-dimensional array', () => {
-            const strategy = new BasicCharacterStrategy();
-            const input = 'MAIN-MENU';
-            const output = [['M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U']];
+    describe('new', () => {
+        test('sets initial string into a two-dimensional array', () => {
+            const input = 'NORMAL';
+            const strategy = new BasicCharacterStrategy(input);
+            const expected = [['N', 'O', 'R', 'M', 'A', 'L']];
 
-            expect(strategy.buildChar(input)).toEqual(output);
+            expect(strategy.char).toEqual(expected);
+        });
+    });
+
+    describe('setChar', () => {
+
+        test('turns a string into a two-dimensional array', () => {
+            const input = 'MAIN-MENU';
+            const strategy = new BasicCharacterStrategy('');
+            const expected = [['M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U']];
+
+            strategy.setChar(input)
+
+            expect(strategy.char).toEqual(expected);
         });
     })
 })

--- a/src/__tests__/characters/styled.ts
+++ b/src/__tests__/characters/styled.ts
@@ -1,53 +1,75 @@
 import StyledCharacterStrategy from "../../characters/styled";
 
 describe('StyledCharacterStrategy', () => {
-    describe('buildChar', () => {
-        test('turns a string into a two-dimensional array with no styles by default', () => {
-            const strategy = new StyledCharacterStrategy();
+    describe('new', () => {
+        test('processes the provided chars', () => {
             const input = 'MAIN-MENU';
-            const output = [['M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U']];
+            const strategy = new StyledCharacterStrategy(input, {bold: true});
+            const expected = [['{bold}M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U{/bold}']];
 
-            expect(strategy.buildChar(input)).toEqual(output);
+            expect(strategy.char).toEqual(expected);
+        });
+    })
+
+    describe('setChar', () => {
+        test('turns a string into a two-dimensional array with no styles by default', () => {
+            const strategy = new StyledCharacterStrategy('');
+            const input = 'MAIN-MENU';
+            const expected = [['M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U']];
+
+            strategy.setChar(input);
+
+            expect(strategy.char).toEqual(expected);
         });
 
         test('adds bold tags', () => {
-            const strategy = new StyledCharacterStrategy({bold: true});
+            const strategy = new StyledCharacterStrategy('', {bold: true});
             const input = 'MAIN-MENU';
-            const output = [['{bold}M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U{/bold}']];
+            const expected = [['{bold}M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U{/bold}']];
 
-            expect(strategy.buildChar(input)).toEqual(output);
+            strategy.setChar(input);
+
+            expect(strategy.char).toEqual(expected);
         });
 
         test("doesn't add bold tags if bold is set to false", () => {
-            const strategy = new StyledCharacterStrategy({bold: false});
+            const strategy = new StyledCharacterStrategy('', {bold: false});
             const input = 'MAIN-MENU';
-            const output = [['M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U']];
+            const expected = [['M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U']];
 
-            expect(strategy.buildChar(input)).toEqual(output);
+            strategy.setChar(input);
+
+            expect(strategy.char).toEqual(expected);
         });
 
         test('adds foreground color tags', () => {
-            const strategy = new StyledCharacterStrategy({fg: 'FF0000'});
+            const strategy = new StyledCharacterStrategy('', {fg: 'FF0000'});
             const input = 'MAIN-MENU';
-            const output = [['{#FF0000-fg}M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U{/#FF0000-fg}']];
+            const expected = [['{#FF0000-fg}M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U{/#FF0000-fg}']];
 
-            expect(strategy.buildChar(input)).toEqual(output);
+            strategy.setChar(input);
+
+            expect(strategy.char).toEqual(expected);
         });
 
         test('adds background color tags', () => {
-            const strategy = new StyledCharacterStrategy({bg: 'CCDDEE'});
+            const strategy = new StyledCharacterStrategy('', {bg: 'CCDDEE'});
             const input = 'MAIN-MENU';
-            const output = [['{#CCDDEE-bg}M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U{/#CCDDEE-bg}']];
+            const expected = [['{#CCDDEE-bg}M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U{/#CCDDEE-bg}']];
 
-            expect(strategy.buildChar(input)).toEqual(output);
+            strategy.setChar(input);
+
+            expect(strategy.char).toEqual(expected);
         });
 
         test('adds multiple styles at the same time', () => {
-            const strategy = new StyledCharacterStrategy({bold: true, bg: 'CCDDEE', fg: 'FF0000'});
+            const strategy = new StyledCharacterStrategy('', {bold: true, bg: 'CCDDEE', fg: 'FF0000'});
             const input = 'MAIN-MENU';
-            const output = [['{#FF0000-fg}{#CCDDEE-bg}{bold}M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U{/bold}{/#CCDDEE-bg}{/#FF0000-fg}']];
+            const expected = [['{#FF0000-fg}{#CCDDEE-bg}{bold}M', 'A', 'I', 'N', '-', 'M', 'E', 'N', 'U{/bold}{/#CCDDEE-bg}{/#FF0000-fg}']];
 
-            expect(strategy.buildChar(input)).toEqual(output);
+            strategy.setChar(input);
+
+            expect(strategy.char).toEqual(expected);
         });
     })
-})
+});

--- a/src/__tests__/objects/components/Position.ts
+++ b/src/__tests__/objects/components/Position.ts
@@ -1,11 +1,29 @@
 import BasicCharacterStrategy from "../../../characters/basic";
 import PositionComponent from "../../../objects/components/position";
+import StyledCharacterStrategy from "../../../characters/styled";
 
 describe('PositionComponent', () => {
-    test('uses basic character strategy by default', () => {
+    test('creates basic character strategy by default', () => {
         const position = new PositionComponent('', 0, 0);
 
         expect(position.characterStrategy)
             .toBeInstanceOf(BasicCharacterStrategy);
+    })
+
+    test('accepts a character strategy in the constructor', () => {
+        const strategy = new StyledCharacterStrategy('test');
+        const position = new PositionComponent(strategy, 0, 0);
+
+        expect(position.characterStrategy).toEqual(strategy);
+    });
+
+    test('delegates setting chars to the current character strategy', () => {
+        const strategy = new BasicCharacterStrategy('');
+        const position = new PositionComponent(strategy, 0, 0);
+        const expected = [['t', 'e', 's', 't']];
+
+        position.setChar('test')
+
+        expect(strategy.char).toEqual(expected);
     })
 });

--- a/src/characters/basic.ts
+++ b/src/characters/basic.ts
@@ -1,7 +1,17 @@
 import { CharacterStrategy } from "../objects/components/position";
 
 export default class BasicCharacterStrategy implements CharacterStrategy {
-    buildChar(char: string) {
-        return [char.split("")];
+    private _char: string[][];
+
+    get char() {
+        return this._char;
+    }
+
+    constructor(chars: string) {
+        this.setChar(chars);
+    }
+
+    setChar(char: string) {
+        this._char = [char.split("")];
     }
 }

--- a/src/characters/styled.ts
+++ b/src/characters/styled.ts
@@ -27,15 +27,19 @@ function buildTag(styleTags: StyleTags, tag: string) {
 }
 
 export default class StyledCharacterStrategy implements CharacterStrategy {
-    private styles: StyleOpts;
     private styleTags: StyleTags;
+    private _char: string[][];
 
-    constructor(opts: StyleOpts = {}) {
-        this.styles = opts;
-        this.styleTags = this._buildTags();
+    get char() {
+        return this._char;
     }
 
-    buildChar(char: string) {
+    constructor(chars: string, opts: StyleOpts = {}) {
+        this.styleTags = this._buildTags(opts);
+        this.setChar(chars);
+    }
+
+    setChar(char: string) {
         const newChar: string[][] = [char.split("")];
         const [openingTags, closingTags] = this.styleTags;
 
@@ -43,14 +47,14 @@ export default class StyledCharacterStrategy implements CharacterStrategy {
         const last = newChar[0].length;
         newChar[0][last - 1] = newChar[0][last - 1] + `${closingTags}`;
 
-        return newChar;
+        this._char = newChar;
     }
 
-    private _buildTags() {
+    private _buildTags(styles) {
         const styleTags: StyleTags = ['', ''];
 
-        Object.keys(this.styles).forEach((styleKey)  => {
-            decorators[styleKey](styleTags, this.styles[styleKey]);
+        Object.keys(styles).forEach((styleKey)  => {
+            decorators[styleKey](styleTags, styles[styleKey]);
         })
 
         return styleTags;

--- a/src/objects/components/position.ts
+++ b/src/objects/components/position.ts
@@ -2,7 +2,8 @@ import {Component} from '../../entities';
 import BasicCharacterStrategy from '../../characters/basic';
 
 export interface CharacterStrategy {
-    buildChar(Char: string): string[][];
+    char: string[][];
+    setChar(Char: string): void;
 }
 
 // What we render
@@ -13,22 +14,25 @@ export default class PositionComponent implements Component {
     x: number;
     y: number;
     z: number;
-    private _char: string[][];
-    private _rawChar: string;
     private _characterStrategy: CharacterStrategy;
 
-    get char(): string[][] {
-        return this._char;
+    get char() {
+        return this._characterStrategy.char;
     }
 
     get characterStrategy(): CharacterStrategy {
         return this._characterStrategy;
     }
 
-    constructor(char: string, x: number, y: number, z: number = 0, absolute = false) {
-        this._characterStrategy = new BasicCharacterStrategy();
-        this._rawChar = char; // save raw char so we have it when we switch strategies
-        this.setChar(char);
+    constructor(defaultCharacterStrategyOrText: CharacterStrategy | string,
+      x: number, y: number, z: number = 0, absolute = false) {
+        if (typeof defaultCharacterStrategyOrText === 'string') {
+            this._characterStrategy = new BasicCharacterStrategy(
+              defaultCharacterStrategyOrText)
+        } else {
+            this._characterStrategy = defaultCharacterStrategyOrText;
+        }
+
         this.x = x;
         this.y = y;
         this.z = z;
@@ -37,11 +41,9 @@ export default class PositionComponent implements Component {
 
     setCharacterStrategy(strategy: CharacterStrategy) {
         this._characterStrategy = strategy;
-        this.setChar(this._rawChar);
     }
 
     setChar(char: string) {
-        this._rawChar = char;
-        this._char = this._characterStrategy.buildChar(char);
+        this._characterStrategy.setChar(char);
     }
 }

--- a/src/objects/mode.ts
+++ b/src/objects/mode.ts
@@ -5,15 +5,14 @@ import {EventType} from '../events';
 import StyledCharacterStrategy from '../characters/styled';
 import BasicCharacterStrategy from '../characters/basic';
 
-const basicStrategy = new BasicCharacterStrategy();
 const characterStrategies = {
-    [ScreenType.Normal]: new StyledCharacterStrategy({
+    [ScreenType.Normal]: new StyledCharacterStrategy(ScreenType.Normal, {
         bold: true,
         fg: '96A537',
         bg: 'FF0000'
     }),
-    [ScreenType.Insert]: basicStrategy,
-    [ScreenType.MainMenu]: basicStrategy
+    [ScreenType.Insert]: new BasicCharacterStrategy(ScreenType.Insert),
+    [ScreenType.MainMenu]: new BasicCharacterStrategy(ScreenType.MainMenu)
 };
 
 export default class Mode {
@@ -38,7 +37,6 @@ export default class Mode {
             if (evt.type === EventType.ScreenTypeChanged) {
                 this.position.setCharacterStrategy(
                   characterStrategies[context.screen]);
-                this.position.setChar(context.screen);
             }
         });
     }


### PR DESCRIPTION
@ThePrimeagen here is what I came up with to improve wasted resources for character strategies.

I have mixed feelings about the updated constructor in `PositionComponent`.

Pros:

- Most of the code base doesn't know or care about the change
- The component stays flexible, although in a slightly different way.
  - Previously, the default character strategy was always a brand new `BasicCharacterStrategy`. Sometimes that default strategy would be created and then thrown away.
  - Now, we accept either a string to generate a basic char strategy from, or we accept a strategy to use.

Cons:

- I'm not sure if the `if`/`else` in the constructor is a good pattern
- The updated `PositionComponent` constructor is ugly. I'm sure there is a better way to include this flexibility, I'm just not sure what it is at the moment. Do we care about the ugliness?

Currently, `setChar` is no longer used anywhere in the code base. I kept it around as promised though, until we decide it doesn't need to be there anymore.

---

The next place I see to make improvements is refactoring the building of style tags to be built all at once rather than building and throwing away strings in each call to `buildTag`. Since the mode line is the only place using styled text at the moment, I think there are probably bigger fish to fry than that.