### PR TITLE
Use cargo-chef to improve docker caching

### DIFF
--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,50 +1,28 @@
-FROM rust:latest AS FETCH_THE_EFFIN_RUST
+# Pin to specific hash since this image is controled by some rando
+FROM lukemathwalker/cargo-chef@sha256:2d30138eea6c5985bb907659834e428e3a1cb3d3db5c26377d2346eeadbeca84 AS chef
 RUN rustup default nightly
-
 WORKDIR /app
-COPY Cargo.toml /app
-COPY Cargo.lock /app
 
-COPY vim_royale_view/Cargo.toml /app/vim_royale_view/Cargo.toml
-COPY vim_royale_server/Cargo.toml /app/vim_royale_server/Cargo.toml
-COPY encoding/Cargo.toml /app/encoding/Cargo.toml
-COPY vim_royale_client/Cargo.toml /app/vim_royale_client/Cargo.toml
-COPY encoding/Cargo.toml /app/encoding/Cargo.toml
-COPY vim_royale/Cargo.toml /app/vim_royale/Cargo.toml
-COPY game/Cargo.toml /app/game/Cargo.toml
-COPY map/Cargo.toml /app/map/Cargo.toml
+# Create the recipe.json containing project structure + cargo files
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-COPY vim_royale/src/main.rs /app/vim_royale/src/main.rs
-COPY vim_royale_view/src/lib.rs /app/vim_royale_view/src/lib.rs
-COPY vim_royale_server/src/main.rs /app/vim_royale_server/src/main.rs
-COPY encoding/src/lib.rs /app/encoding/src/lib.rs
-COPY vim_royale_client/src/main.rs /app/vim_royale_client/src/main.rs
-COPY encoding/src/lib.rs /app/encoding/src/lib.rs
-COPY vim_royale/src/lib.rs /app/vim_royale/src/lib.rs
-COPY game/src/lib.rs /app/game/src/lib.rs
-COPY map/src/lib.rs /app/map/src/lib.rs
 
-run cargo fetch
+FROM chef AS builder 
+# Build dependencies - this is the caching Docker layer!
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 
-RUN pwd
-
-COPY vim_royale_server /app/vim_royale_server
-COPY vim_royale_client /app/vim_royale_client
-COPY vim_royale_view /app/vim_royale_view
-COPY vim_royale /app/vim_royale
-
-COPY encoding /app/encoding
-COPY map /app/map
-COPY game /app/game
-
+# Build application
+COPY . .
 WORKDIR /app/vim_royale_server
-RUN pwd
 RUN cargo build --release
 
-FROM debian:latest
+# Build deployable image
+FROM debian:buster-slim AS runtime
 EXPOSE 42069
 WORKDIR /app
 RUN apt update && apt install -y ca-certificates
-COPY --from=FETCH_THE_EFFIN_RUST /app/target/release/vim_royale_server /app
+COPY --from=builder /app/target/release/vim_royale_server /app
 CMD ["sh", "-c", "RUST_LOG=info /app/vim_royale_server"]
-


### PR DESCRIPTION
Hey @ThePrimeagen -- this is what the Dockerfile would look like using cargo-chef that I mentioned on Twitter

Pros:
- Prevent busting the docker cache when you change your main.rs/lib.rs 
- Reduces Dockerfile length and needing to update all of your COPY commands if you refactor

Cons:
- One additional stage in Dockerfile (to generate the recipe.json)
- Depending on random 3rd party cargo plugin https://github.com/LukeMathWalker/cargo-chef (although it seems active with last commit 8 days ago and 800 stars...)

The PR also uses the slim debian image as the base for the final stage which saves ~50MB in the final runtime image